### PR TITLE
아카이브 교류에 따른 점수 차등분배 및 차감 구현 완료

### DIFF
--- a/src/main/java/CHOIGANGMEDIA/CAUCLUB/controller/ArchiveController.java
+++ b/src/main/java/CHOIGANGMEDIA/CAUCLUB/controller/ArchiveController.java
@@ -24,7 +24,7 @@ public class ArchiveController {
     @ResponseBody
     @RequestMapping(value = "/{memberId}/{clubId}/newArchive", method = RequestMethod.POST)
     public boolean registerNewArchive(@PathVariable int clubId, @RequestParam String contents,
-                                      @RequestParam ArrayList<String> pictureUrls, @RequestParam String title) throws Exception{
+                                      @RequestParam ArrayList<String> pictureUrls, @RequestParam String title, @RequestParam int isMutual) throws Exception{
 
         Archive archive = new Archive();
         Date now = new Date();
@@ -43,8 +43,9 @@ public class ArchiveController {
         archive.setLikeMember(likeMemberList);
         archive.setReportCount(0);
         archive.setReportMemberList(reportMemberList);
+        archive.setIsMutual(isMutual);
         archiveService.registerNewArchive(archive);
-        archiveService.getScoreByArchive(clubId);
+        archiveService.getScoreByArchive(clubId, isMutual);
         System.out.println("아카이브 생성이 완료되었습니다.");
         return true;
     }

--- a/src/main/java/CHOIGANGMEDIA/CAUCLUB/domain/Archive.java
+++ b/src/main/java/CHOIGANGMEDIA/CAUCLUB/domain/Archive.java
@@ -22,4 +22,5 @@ public class Archive {
     private ArrayList<String> likeMember;
     private int reportCount;
     private ArrayList<String> reportMemberList;
+    private int isMutual;
 }

--- a/src/main/java/CHOIGANGMEDIA/CAUCLUB/repository/ArchiveRepository.java
+++ b/src/main/java/CHOIGANGMEDIA/CAUCLUB/repository/ArchiveRepository.java
@@ -17,5 +17,5 @@ public interface ArchiveRepository {
     List<Archive> viewMyClubArchive(int clubId) throws Exception;
     int setArchivePk() throws Exception;
     void plusArchivePk() throws Exception;
-    void plusScoreByArchive(int clubId) throws Exception;
+    void plusScoreByArchive(int clubId, int isMutual) throws Exception;
 }

--- a/src/main/java/CHOIGANGMEDIA/CAUCLUB/repository/MemoryArchiveRepository.java
+++ b/src/main/java/CHOIGANGMEDIA/CAUCLUB/repository/MemoryArchiveRepository.java
@@ -21,11 +21,17 @@ public class MemoryArchiveRepository implements ArchiveRepository{
         ApiFuture<DocumentSnapshot> future = docRef.get();
         DocumentSnapshot document = future.get();
         int clubId = Objects.requireNonNull(document.toObject(Archive.class)).getClubId();
+        int isMutual = Objects.requireNonNull(document.toObject(Archive.class)).getIsMutual();
         DocumentReference documentReference = dbFirestore.collection("Club").document(String.valueOf(clubId));
         ApiFuture<DocumentSnapshot> future1 = documentReference.get();
         DocumentSnapshot document1 = future1.get();
         int clubScore = Objects.requireNonNull(document1.toObject(Club.class)).getScore();
-        clubScore -= 15;
+        if(isMutual == 1){
+            clubScore -= 25;
+        }
+        else{
+            clubScore -= 15;
+        }
         ApiFuture<WriteResult> future2 = documentReference.update("score",clubScore);
         dbFirestore.collection("Archive").document(String.valueOf(archiveId)).delete();
         return true;
@@ -172,13 +178,18 @@ public class MemoryArchiveRepository implements ArchiveRepository{
     }
 
     @Override
-    public void plusScoreByArchive(int clubId) throws Exception {
+    public void plusScoreByArchive(int clubId, int isMutual) throws Exception {
         Firestore firestore = FirestoreClient.getFirestore();
         DocumentReference documentReference = firestore.collection("Club").document(String.valueOf(clubId));
         ApiFuture<DocumentSnapshot> future = documentReference.get();
         DocumentSnapshot document = future.get();
         int clubScore = Objects.requireNonNull(document.toObject(Club.class)).getScore();
-        clubScore += 15;
+        if(isMutual == 1){  // 교류인 아카이브
+            clubScore += 25;
+        }
+        else{
+            clubScore += 15;
+        }
         ApiFuture<WriteResult> future1 = documentReference.update("score",clubScore);
     }
 }

--- a/src/main/java/CHOIGANGMEDIA/CAUCLUB/service/ArchiveService.java
+++ b/src/main/java/CHOIGANGMEDIA/CAUCLUB/service/ArchiveService.java
@@ -53,7 +53,7 @@ public class ArchiveService {
         return archiveRepository.setArchivePk();
     }
 
-    public void getScoreByArchive(int clubId) throws Exception{
-        archiveRepository.plusScoreByArchive(clubId);
+    public void getScoreByArchive(int clubId, int isMutual) throws Exception{
+        archiveRepository.plusScoreByArchive(clubId, isMutual);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     host: smtp.gmail.com
     port: 587
     username: kitaecoding999@gmail.com
-    password: kszq mewe ewyy nnpi
+    password: drlc tkcf lhug fazv
     thymeleaf:
       cache: false
       prefix: classpath:/templates


### PR DESCRIPTION
## 제목
아카이브 교류에 따른 점수 차등분배 및 차감 구현 완료
## 작업내용
- [x] 기능 추가
- [x] 기능 수정
- [ ] 버그 수정
- [x] 기타 설정

## 수정내용
1. 아카이브 도메인에 교류인지 아닌지 판단해주는 isMutual 추가
2. 아카이브가 교류인지 아닌지에 따라 동아리에 들어오고 삭제되는 점수 차등 분배
3. 이메일 인증 관련 2차 비밀번호 수정
-

## 주의 사항